### PR TITLE
Ensure LLM uses redacted previews and align storage schema

### DIFF
--- a/apps/worker/services/reports.py
+++ b/apps/worker/services/reports.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, List
 
 from weasyprint import HTML
 
+from pathlib import Path
+
 from apps.common.supabase import get_supabase
 
 try:
@@ -89,9 +91,10 @@ def build_export_zip(user_id: str, *, payslips: List[Dict[str, Any]], files: Lis
         archive.writestr("anomalies.json", json.dumps(anomalies, indent=2, default=str))
         archive.writestr("settings.json", json.dumps(settings, indent=2, default=str))
         for file_row in files:
-            if not file_row.get("storage_path"):
+            key = file_row.get("s3_key_original") or file_row.get("storage_path")
+            if not key:
                 continue
-            archive.writestr(f"pdfs/{file_row['storage_path'].split('/')[-1]}", "")
+            archive.writestr(f"pdfs/{Path(key).name}", "")
     return ReportArtifact(filename=f"{user_id}_export.zip", bytes=buf.getvalue(), content_type="application/zip")
 
 

--- a/docs/DPIA.md
+++ b/docs/DPIA.md
@@ -12,7 +12,7 @@ Payslip Companion ingests employee payslips to extract compensation insights. Th
 ## Processing Activities
 1. PDFs uploaded by the authenticated user are scanned for malware and stored under `{user_id}/{file_id}.pdf`.
 2. Native parsers extract text; when PDFs are scanned or low fidelity the worker rasterises pages and runs Tesseract OCR locally. OCR output never leaves the worker and feeds the same validation pipeline as native text.
-3. Regex-based redaction removes NI/PPS/IBAN/DOB/address values before preview generation. Only redacted images are sent to OpenAI GPT-4o-mini for key-value reinforcement.
+3. Regex-based redaction removes NI/PPS/IBAN/DOB/address values before preview generation. Only redacted preview PNGs (with highlight coordinates normalised to percentages) are sent to OpenAI GPT-4o-mini for key-value reinforcement.
 4. Parsed values are validated (identity rule, YTD monotonicity, date/tax-code checks) and persisted to `payslips`. Review flags trigger UI workflows.
 4. Anomaly detection compares against historical payslips to flag drops, regressions, and code changes. Findings populate the `anomalies` table.
 5. Users may request dossiers, HR packs, or exports; generated PDFs/ZIPs are stored back into Supabase Storage with signed URL delivery.

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -8,7 +8,7 @@
 5. After reset, clear `disable_llm` metadata, restart the worker, and monitor the next five jobs to confirm tokens/costs are being recorded again.
 
 ## Storage / RLS Troubleshooting
-1. Check `files` for the `user_id`/`file_id` pair and ensure `storage_path` matches `{user_id}/{file_id}.pdf`.
+1. Check `files` for the `user_id`/`file_id` pair and ensure `s3_key_original` matches `{user_id}/{file_id}.pdf` (fallback `storage_path` remains for legacy rows).
 2. With the service role key, call the Supabase Storage signed URL API; if the object is missing, re-upload from the original PDF (kept in the export bundle under `/pdfs`).
 3. Validate storage policies: the payslips bucket must enforce `starts_with(object.name, auth.uid())`.
 4. If RLS blocks table reads, verify JWT `sub` equals the `user_id` and that the role has `files`/`payslips` select policies granting access.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -12,7 +12,7 @@
 
 ## PII Minimisation & LLM Safety
 - Native parsing (pdfplumber/PyMuPDF) and OCR (Tesseract) run entirely inside the worker. OCR text stays in memory long enough to improve native field extraction and is never persisted or transmitted externally.
-- The redaction step executes before any LLM call; only rasterised redacted images are shared with OpenAI. Raw PDFs, native text, and OCR output remain local to the worker.
+- The redaction step executes before any LLM call; only the generated redacted preview PNGs (stored as `{user_id}/{file_id}_redacted.png`) are shared with OpenAI. Raw PDFs, native text, and OCR output remain local to the worker and never cross the network boundary.
 - If the LLM spend cap is hit or OpenAI errors, the system falls back to native/OCR extraction and flags the job for manual review. No additional data leaves the environment during fallback.
 - `llm_usage` logs capture tokens and cost to support audit and cap enforcement.
 

--- a/migrations/0003_fix_redactions_and_paths.sql
+++ b/migrations/0003_fix_redactions_and_paths.sql
@@ -1,0 +1,32 @@
+-- Fix redactions schema mismatches and ensure path compatibility
+ALTER TABLE public.redactions
+ADD COLUMN IF NOT EXISTS user_id uuid;
+
+UPDATE public.redactions r
+SET user_id = f.user_id
+FROM public.files f
+WHERE r.file_id = f.id
+  AND r.user_id IS NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'redactions'
+      AND policyname = 'redactions_own'
+  ) THEN
+    EXECUTE $$
+      CREATE POLICY redactions_own ON public.redactions
+      FOR ALL
+      USING (user_id = auth.uid())
+      WITH CHECK (user_id = auth.uid());
+    $$;
+  END IF;
+END $$;
+
+ALTER TABLE public.files
+ADD COLUMN IF NOT EXISTS storage_path text;
+
+UPDATE public.files
+SET storage_path = COALESCE(storage_path, s3_key_original);

--- a/scripts/fixtures/ie_scan.pdf
+++ b/scripts/fixtures/ie_scan.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 254 >>
+stream
+BT /F1 14 Tf 72 750 Td (Emerald Services Scan) Tj ET
+BT /F1 14 Tf 72 726 Td (Employee: Mary Byrne) Tj ET
+BT /F1 14 Tf 72 702 Td (Gross Pay: €3,050.00) Tj ET
+BT /F1 14 Tf 72 678 Td (Net Pay: €2,300.00) Tj ET
+BT /F1 14 Tf 72 654 Td (Tax Code: S1) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000546 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+626
+%%EOF

--- a/scripts/fixtures/ie_text.pdf
+++ b/scripts/fixtures/ie_text.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 252 >>
+stream
+BT /F1 14 Tf 72 750 Td (Emerald Services) Tj ET
+BT /F1 14 Tf 72 726 Td (Employee: Sean O'Malley) Tj ET
+BT /F1 14 Tf 72 702 Td (Gross Pay: €3,000.00) Tj ET
+BT /F1 14 Tf 72 678 Td (Net Pay: €2,280.00) Tj ET
+BT /F1 14 Tf 72 654 Td (Tax Code: S1) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000544 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+624
+%%EOF

--- a/scripts/fixtures/multi_page.pdf
+++ b/scripts/fixtures/multi_page.pdf
@@ -1,0 +1,35 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 189 >>
+stream
+BT /F1 14 Tf 72 750 Td (Quarterly Summary) Tj ET
+BT /F1 14 Tf 72 726 Td (Page 1 content) Tj ET
+BT /F1 14 Tf 72 682 Td (--- Page Break ---) Tj ET
+BT /F1 14 Tf 72 658 Td (Page 2 totals) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000481 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+561
+%%EOF

--- a/scripts/fixtures/password.pdf
+++ b/scripts/fixtures/password.pdf
@@ -1,0 +1,34 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 161 >>
+stream
+BT /F1 14 Tf 72 750 Td (Password Fixture) Tj ET
+BT /F1 14 Tf 72 726 Td (Password: test123) Tj ET
+BT /F1 14 Tf 72 702 Td (Used to exercise decrypt pipeline) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000453 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+533
+%%EOF

--- a/scripts/fixtures/uk_scan.pdf
+++ b/scripts/fixtures/uk_scan.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 247 >>
+stream
+BT /F1 14 Tf 72 750 Td (ACME Payroll Scan) Tj ET
+BT /F1 14 Tf 72 726 Td (Employer: ACME Ltd) Tj ET
+BT /F1 14 Tf 72 702 Td (Gross Pay: £3,200.00) Tj ET
+BT /F1 14 Tf 72 678 Td (Income Tax: £520.00) Tj ET
+BT /F1 14 Tf 72 654 Td (NI: £280.00) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000539 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+619
+%%EOF

--- a/scripts/fixtures/uk_text.pdf
+++ b/scripts/fixtures/uk_text.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 244 >>
+stream
+BT /F1 14 Tf 72 750 Td (ACME Payroll) Tj ET
+BT /F1 14 Tf 72 726 Td (Employee: Jane Doe) Tj ET
+BT /F1 14 Tf 72 702 Td (Gross Pay: £3,200.00) Tj ET
+BT /F1 14 Tf 72 678 Td (Net Pay: £2,165.00) Tj ET
+BT /F1 14 Tf 72 654 Td (Tax Code: 1257L) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000536 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+616
+%%EOF

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -51,9 +51,12 @@ from apps.worker.tasks import job_detect_anomalies, job_dossier, job_export_all,
 @pytest.fixture
 def ocr_mapping():
     return {
+        "uk_text": "ACME Payroll\nEmployer: ACME Ltd\nGross Pay: £3,200.00\nIncome Tax: £520.00\nNational Insurance: £280.00\nPension (Employee): £160.00\nStudent Loan: £75.00\nNet Pay: £2,165.00\nTax Code: 1257L",  # noqa: E501
         "uk_scan": "Example Payslip\nEmployer: ACME Ltd\nGross Pay: £3,200.00\nIncome Tax: £520.00\nNational Insurance: £280.00\nPension (Employee): £160.00\nStudent Loan: £75.00\nNet Pay: £2,165.00\nTax Code: 1257L",  # noqa: E501
+        "ie_text": "Irish Payslip\nEmployer: Emerald Services\nGross Pay: €3,000.00\nIncome Tax: €450.00\nPRSI: €180.00\nPension (Employee): €90.00\nNet Pay: €2,280.00\nTax Code: S1",  # noqa: E501
         "ie_scan": "Irish Payslip\nEmployer: Emerald Services\nGross Pay: €3,000.00\nIncome Tax: €450.00\nPRSI: €180.00\nPension (Employee): €90.00\nNet Pay: €2,280.00\nTax Code: S1",  # noqa: E501
-        "password": "Confidential Payslip\nGross Pay: £2,000.00\nNet Pay: £1,400.00\nTax Code: 1257L",
+        "password": "Confidential Payslip\nGross Pay: £2,000.00\nIncome Tax: £300.00\nNational Insurance: £150.00\nPension (Employee): £100.00\nStudent Loan: £50.00\nNet Pay: £1,400.00\nTax Code: 1257L",
+        "multi_page": "Quarterly Summary\nGross Pay: £9,600.00\nIncome Tax: £1,560.00\nNational Insurance: £840.00\nPension (Employee): £300.00\nStudent Loan: £0.00\nNet Pay: £6,900.00",
     }
 
 
@@ -90,7 +93,14 @@ def test_end_to_end_pipeline(monkeypatch, fake_supabase, fake_storage, fixture_s
     status_map: dict[str, str] = {}
     for fixture in fixtures:
         file_id = fixture
-        fake_supabase.insert_row("files", {"id": file_id, "user_id": user_id})
+        fake_supabase.insert_row(
+            "files",
+            {
+                "id": file_id,
+                "user_id": user_id,
+                "s3_key_original": f"{user_id}/{file_id}.pdf",
+            },
+        )
         job_id = f"job-{file_id}"
         fake_supabase.insert_row(
             "jobs",

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from apps.common.models import JobKind, JobStatus
+from apps.worker.services.llm import LlmResponse
+from apps.worker.tasks import job_extract
+
+
+def test_llm_uses_redacted_preview_and_percent_boxes(monkeypatch, fake_supabase, fake_storage, fixture_state):
+    user_id = "user-privacy"
+    file_id = "uk_text"
+    preview_calls: dict[str, object] = {}
+
+    def fake_llm(user: str, file: str | None, previews):
+        preview_calls["user"] = user
+        preview_calls["file"] = file
+        preview_calls["previews"] = previews
+        return LlmResponse(
+            payload={
+                "country": "UK",
+                "currency": "GBP",
+                "gross": 3200.0,
+                "net": 2165.0,
+                "tax_income": 520.0,
+                "ni_prsi": 280.0,
+                "pension_employee": 160.0,
+                "pension_employer": 0.0,
+                "student_loan": 75.0,
+                "other_deductions": [],
+                "ytd": {},
+                "confidence_overall": 0.95,
+            },
+            tokens=0,
+            cost=0.0,
+        )
+
+    monkeypatch.setattr("apps.worker.tasks.get_supabase", lambda: fake_supabase)
+    monkeypatch.setattr("apps.worker.tasks._ensure_storage_service", lambda: fake_storage)
+    monkeypatch.setattr("apps.worker.tasks.scan_bytes", lambda *args, **kwargs: None)
+    send_calls: list[tuple[str, list[str]]] = []
+
+    monkeypatch.setattr("apps.worker.tasks._llm_extract", fake_llm)
+    monkeypatch.setattr(
+        "apps.worker.tasks.celery_app.send_task",
+        lambda name, args=None, kwargs=None: send_calls.append((name, args or [])),
+    )
+
+    fake_supabase.insert_row(
+        "files",
+        {
+            "id": file_id,
+            "user_id": user_id,
+            "s3_key_original": f"{user_id}/{file_id}.pdf",
+        },
+    )
+    fake_supabase.insert_row(
+        "jobs",
+        {
+            "id": "job-privacy",
+            "user_id": user_id,
+            "file_id": file_id,
+            "kind": JobKind.EXTRACT.value,
+            "status": JobStatus.QUEUED.value,
+            "meta": {},
+        },
+    )
+
+    job_extract("job-privacy")
+
+    assert preview_calls["user"] == user_id
+    assert preview_calls["file"] == file_id
+    previews = preview_calls["previews"]
+    assert isinstance(previews, list) and previews
+    for preview in previews:
+        assert preview.path.endswith("_redacted.png")
+
+    redaction_rows = fake_supabase.tables["redactions"]
+    assert redaction_rows, "redactions were not recorded"
+    boxes = redaction_rows[0]["boxes"]
+    for box in boxes:
+        for key in ("x", "y", "w", "h"):
+            assert 0.0 <= box[key] <= 100.0
+
+    job_row = fake_supabase.table_select_single("jobs", match={"id": "job-privacy"})
+    highlights = job_row["meta"]["highlights"]
+    for box in highlights:
+        for key in ("x", "y", "w", "h"):
+            assert 0.0 <= box[key] <= 100.0
+    assert job_row["meta"]["imageUrl"].endswith("_redacted.png")
+    assert all(call[0] == "jobs.detect_anomalies" for call in send_calls)


### PR DESCRIPTION
## Summary
- ensure the worker converts highlight boxes to percentages, uploads the redacted preview, and only sends redacted imagery to the LLM
- rely on canonical S3 key columns during cleanup/export and add an additive migration for redactions.user_id plus legacy storage paths
- add sanitized PDF fixtures, extend the end-to-end test coverage, and document the redacted-only privacy flow across security runbooks

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68de0baf50ac832aa2364389317457f0