### PR TITLE
Fix snooze handler when anomaly lacks payslip

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -106,10 +106,10 @@ export default function Dashboard() {
   };
 
   const confirmSnooze = async () => {
-    if (!selectedAnomaly?.payslips) return;
+    const payslip = selectedAnomaly?.payslips;
+    if (!payslip) return;
 
     // Calculate snooze date based on payslip period type
-    const payslip = selectedAnomaly.payslips;
     const baseDate = new Date(payslip.pay_date || new Date());
     let snoozedUntil = new Date(baseDate);
 


### PR DESCRIPTION
## Summary
- guard the dashboard snooze confirmation handler when the anomaly has no joined payslip data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4243f16c832a9dd875773a8cd952