### PR TITLE
Fix Supabase health probe authentication

### DIFF
--- a/src/components/SupabaseStatusProbe.tsx
+++ b/src/components/SupabaseStatusProbe.tsx
@@ -20,7 +20,8 @@ export default function SupabaseStatusProbe() {
 
   useEffect(() => {
     const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-    if (!supabaseUrl) {
+    const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+    if (!supabaseUrl || !supabaseAnonKey) {
       setStatus("error");
       return;
     }
@@ -34,6 +35,10 @@ export default function SupabaseStatusProbe() {
         const response = await fetch(`${normalizeUrl(supabaseUrl)}${HEALTH_PATH}`, {
           method: "GET",
           mode: "cors",
+          headers: {
+            apikey: supabaseAnonKey,
+            Authorization: `Bearer ${supabaseAnonKey}`,
+          },
           signal: controller.signal,
         });
         if (!mounted) {


### PR DESCRIPTION
## Summary
- require the Supabase anon key before probing the health endpoint
- send apikey and bearer authorization headers to the Supabase health check so it succeeds in production

## Testing
- npm run lint *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68de49aea8d8832aa9b9f96af702759f