### PR TITLE
Document Render deploy guardrails and env template

### DIFF
--- a/CODEX_RUNLOG.md
+++ b/CODEX_RUNLOG.md
@@ -8,9 +8,10 @@
 - Extended unit, regression, snapshot, and end-to-end tests covering validations, anomalies, history generation, OCR fixtures, and PDF rendering.
 
 ## Render deploy guardrails (Oct 2024)
-- Python 3.12 is enforced on Render via `apps/api/runtime.txt` and `apps/worker/runtime.txt`; keep both files in sync with the desired patch release.
-- Render builds should install dependencies with wheel-friendly constraints: `pip install -r apps/worker/requirements.txt -c constraints.txt --prefer-binary` (same for API service).
-- Verify locally by creating a Python 3.12 virtualenv: `python -m venv .venv && source .venv/bin/activate`, check `python --version`, then run `pip install -r apps/worker/requirements.txt -c constraints.txt --prefer-binary`; the resolver should download wheels with no `maturin` compilation output.
+- Python 3.12 is enforced on Render via `apps/api/runtime.txt` and `apps/worker/runtime.txt`; keep both files in sync with the desired patch release (currently 3.12.3).
+- Render builds should run `pip install --upgrade pip && pip install --prefer-binary -r requirements.txt -c ../../constraints.txt` so wheels for orjson/pydantic-core/PyMuPDF are downloaded instead of compiling via maturin.
+- Verify locally by creating a Python 3.12 virtualenv: `python -m venv .venv && source .venv/bin/activate`, check `python --version`, then run `pip install --prefer-binary -r apps/worker/requirements.txt -c constraints.txt`; the resolver should download wheels with no `maturin` compilation output.
+- Post-deploy checklist: `GET /healthz` should return `{"supabase":"ok","redis":"ok"}`, `celery -A apps.worker.celery_app.celery_app inspect ping` reports `OK`, and a sample PDF job moves queued → running → done/needs_review.
 
 ## Local Development
 1. Copy `apps/api/.env.sample` to `apps/api/.env` (or set environment variables) and populate Supabase, Redis, and OpenAI credentials.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,17 @@ The anon key shipped in previous revisions has been revoked; production and prev
 
 ## Render deployment
 
-- Python 3.12 runtimes are pinned via `apps/api/runtime.txt` and `apps/worker/runtime.txt`.
-- Configure `REDIS_URL` with your Render Redis instance in TLS form, e.g. `rediss://default:<token>@<host>:6379`.
+- Python 3.12 is enforced by `apps/api/runtime.txt` and `apps/worker/runtime.txt`; keep both files on the same patch version (currently `3.12.3`).
+- Recommended build command for both the web service and worker: `pip install --upgrade pip && pip install --prefer-binary -r requirements.txt -c ../../constraints.txt`.
+- Required environment variables:
+  - `SUPABASE_URL`
+  - `SUPABASE_SERVICE_ROLE_KEY`
+  - `SUPABASE_STORAGE_BUCKET=payslips`
+  - `REDIS_URL=rediss://default:<token>@<host>:6379`
+  - `OPENAI_API_KEY` (optional for LLM features)
+  - `INTERNAL_TOKEN`
+- Health check: `GET /healthz` returns `{"supabase":"ok","redis":"ok"}` when Supabase and Redis connectivity are healthy.
+- Troubleshooting: maturin/Cargo build failures indicate Render is not using Python 3.12 or `--prefer-binary`; redeploy after correcting the runtime and build command.
 - Example worker start command: `celery -A apps.worker.celery_app worker --loglevel=INFO --concurrency=2`.
 
 ## CI safety checks

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,4 +1,4 @@
-# On Render build, run: pip install -r requirements.txt -c ../../constraints.txt --prefer-binary
+# On Render, build with: pip install --upgrade pip && pip install --prefer-binary -r requirements.txt -c ../../constraints.txt
 fastapi==0.111.0
 uvicorn[standard]==0.29.0
 python-dotenv==1.0.1

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -1,4 +1,4 @@
-# On Render build, run: pip install -r requirements.txt -c ../../constraints.txt --prefer-binary
+# On Render, build with: pip install --upgrade pip && pip install --prefer-binary -r requirements.txt -c ../../constraints.txt
 celery==5.3.6
 redis==5.0.4
 supabase==2.3.4

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,5 @@
-# Render-friendly wheels for Python 3.12
+# Prefer stable wheels on Render (Python 3.12)
 orjson>=3.9
 pydantic==2.7.1
 pydantic-core==2.18.2
+PyMuPDF==1.24.4

--- a/render.env.example
+++ b/render.env.example
@@ -1,0 +1,21 @@
+# Render deployment environment template
+# Copy relevant keys into each Render service (Web/API + Worker).
+# Rotate secrets after pasting in UI.
+
+# Supabase configuration
+SUPABASE_URL=https://<your-supabase-project>.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+SUPABASE_STORAGE_BUCKET=payslips
+
+# Redis / Celery (TLS URL from Upstash or equivalent)
+REDIS_URL=rediss://default:<token>@<host>:6379
+
+# Internal API auth
+INTERNAL_TOKEN=<internal-worker-token>
+
+# Optional integrations
+OPENAI_API_KEY=<openai-api-key-or-remove>
+
+# Frontend defaults (if deploying SPA via Render static site)
+VITE_SUPABASE_URL=https://<your-supabase-project>.supabase.co
+VITE_SUPABASE_ANON_KEY=<rotated-anon-key>


### PR DESCRIPTION
## Summary
- document the Python 3.12 runtime pin and binary wheel build command for Render in the README and runbooks
- align requirements constraints with the wheel-friendly settings and capture them in constraints.txt
- add a render.env.example template covering the shared environment variables for Render services

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4179fbc3c832aa0065e368e9cb5d8